### PR TITLE
ログカテゴリごとに出力有無判定、色付きのログ出力できるようにする

### DIFF
--- a/Runtime/LogLevelLogOutputChecker.cs
+++ b/Runtime/LogLevelLogOutputChecker.cs
@@ -1,4 +1,7 @@
-﻿namespace Extreal.Core.Logging
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Extreal.Core.Logging
 {
     /// <summary>
     /// Class used by default to check if logs should be output.
@@ -6,9 +9,23 @@
     public class LogLevelLogOutputChecker : ILogOutputChecker
     {
         private LogLevel logLevel = LogLevel.Info;
+        private readonly ICollection<string> categories;
 
         /// <summary>
-        /// Initializes LogOutputChecker.
+        /// Creates LogLevelLogOutputChecker.
+        /// </summary>
+        /// <param name="categories">Category to output logs.</param>
+        [SuppressMessage("Usage", "CC0057")]
+        public LogLevelLogOutputChecker(ICollection<string> categories = null)
+        {
+            if (categories != null && categories.Count != 0)
+            {
+                this.categories = new HashSet<string>(categories);
+            }
+        }
+
+        /// <summary>
+        /// Initializes LogLevelLogOutputChecker.
         /// </summary>
         /// <param name="logLevel">LogLevel to be set.</param>
         public void Initialize(LogLevel logLevel)
@@ -21,6 +38,6 @@
         /// <param name="logCategory">Log category used to check.</param>
         /// <returns>True if logs should be output, false otherwise.</returns>
         public bool IsOutput(LogLevel logLevel, string logCategory)
-            => this.logLevel <= logLevel;
+            => this.logLevel <= logLevel && (categories?.Contains(logCategory) ?? true);
     }
 }

--- a/Runtime/UnityDebugLogFormat.cs
+++ b/Runtime/UnityDebugLogFormat.cs
@@ -1,0 +1,33 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using UnityEngine;
+
+namespace Extreal.Core.Logging
+{
+    /// <summary>
+    /// Class that holds the format of the log output by UnityDebugLogWriter.
+    /// </summary>
+    public class UnityDebugLogFormat
+    {
+        /// <summary>
+        /// Target log category.
+        /// </summary>
+        public string Category { get; }
+
+        /// <summary>
+        /// Color for log.
+        /// </summary>
+        public string ColorRGB { get; }
+
+        /// <summary>
+        /// Creates UnityDebugLogFormat.
+        /// </summary>
+        /// <param name="category">Target log category.</param>
+        /// <param name="color">Color for log.</param>
+        [SuppressMessage("Usage", "CC0057")]
+        public UnityDebugLogFormat(string category, Color color = default)
+        {
+            Category = category;
+            ColorRGB = $"#{ColorUtility.ToHtmlStringRGB(color)}";
+        }
+    }
+}

--- a/Runtime/UnityDebugLogFormat.cs.meta
+++ b/Runtime/UnityDebugLogFormat.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1f2052d8285b4c6483cfbd82e1428a3c
+timeCreated: 1678086459

--- a/Runtime/UnityDebugLogWriter.cs
+++ b/Runtime/UnityDebugLogWriter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text;
 using UnityEngine;
 
@@ -18,8 +19,8 @@ namespace Extreal.Core.Logging
         /// </summary>
         /// <param name="formats">Log format.</param>
         [SuppressMessage("Usage", "CC0057")]
-        public UnityDebugLogWriter(IDictionary<string, UnityDebugLogFormat> formats = null)
-            => this.formats = formats;
+        public UnityDebugLogWriter(ICollection<UnityDebugLogFormat> formats = null)
+            => this.formats = formats?.ToDictionary(format => format.Category, format => format);
 
         /// <summary>
         /// Logs message and exception.

--- a/Runtime/UnityDebugLogWriter.cs
+++ b/Runtime/UnityDebugLogWriter.cs
@@ -12,7 +12,7 @@ namespace Extreal.Core.Logging
     /// </summary>
     public class UnityDebugLogWriter : ILogWriter
     {
-        private readonly IDictionary<string, UnityDebugLogFormat> formats;
+        private readonly IDictionary<string, string> formats;
 
         /// <summary>
         /// Creates UnityDebugLogWriter.
@@ -20,7 +20,7 @@ namespace Extreal.Core.Logging
         /// <param name="formats">Log format.</param>
         [SuppressMessage("Usage", "CC0057")]
         public UnityDebugLogWriter(ICollection<UnityDebugLogFormat> formats = null)
-            => this.formats = formats?.ToDictionary(format => format.Category, format => format);
+            => this.formats = formats?.ToDictionary(format => format.Category, format => format.ColorRGB);
 
         /// <summary>
         /// Logs message and exception.
@@ -60,11 +60,11 @@ namespace Extreal.Core.Logging
         private string LogFormat(string logCategory, LogLevel logLevel, string message, Exception exception = null)
         {
             var stringBuilder = new StringBuilder();
-            UnityDebugLogFormat format = null;
-            formats?.TryGetValue(logCategory, out format);
-            if (format != null)
+            string colorRGB = null;
+            formats?.TryGetValue(logCategory, out colorRGB);
+            if (colorRGB != null)
             {
-                stringBuilder.Append("<color=").Append(format.ColorRGB).Append(">");
+                stringBuilder.Append("<color=").Append(colorRGB).Append(">");
             }
             _ = stringBuilder
                 .Append("[")
@@ -77,7 +77,7 @@ namespace Extreal.Core.Logging
             {
                 _ = stringBuilder.Append("\n----------\n").Append(exception);
             }
-            if (format != null)
+            if (colorRGB != null)
             {
                 stringBuilder.Append("</color>");
             }

--- a/Runtime/UnityDebugLogWriter.cs
+++ b/Runtime/UnityDebugLogWriter.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using UnityEngine;
 
@@ -9,6 +11,16 @@ namespace Extreal.Core.Logging
     /// </summary>
     public class UnityDebugLogWriter : ILogWriter
     {
+        private readonly IDictionary<string, UnityDebugLogFormat> formats;
+
+        /// <summary>
+        /// Creates UnityDebugLogWriter.
+        /// </summary>
+        /// <param name="formats">Log format.</param>
+        [SuppressMessage("Usage", "CC0057")]
+        public UnityDebugLogWriter(IDictionary<string, UnityDebugLogFormat> formats = null)
+            => this.formats = formats;
+
         /// <summary>
         /// Logs message and exception.
         /// </summary>
@@ -44,9 +56,15 @@ namespace Extreal.Core.Logging
             }
         }
 
-        private static string LogFormat(string logCategory, LogLevel logLevel, string message, Exception exception = null)
+        private string LogFormat(string logCategory, LogLevel logLevel, string message, Exception exception = null)
         {
             var stringBuilder = new StringBuilder();
+            UnityDebugLogFormat format = null;
+            formats?.TryGetValue(logCategory, out format);
+            if (format != null)
+            {
+                stringBuilder.Append("<color=").Append(format.ColorRGB).Append(">");
+            }
             _ = stringBuilder
                 .Append("[")
                 .Append(logLevel)
@@ -57,6 +75,10 @@ namespace Extreal.Core.Logging
             if (exception != null)
             {
                 _ = stringBuilder.Append("\n----------\n").Append(exception);
+            }
+            if (format != null)
+            {
+                stringBuilder.Append("</color>");
             }
             return stringBuilder.ToString();
         }

--- a/Tests/Runtime/LoggingManagerTest.cs
+++ b/Tests/Runtime/LoggingManagerTest.cs
@@ -350,6 +350,75 @@ namespace Extreal.Core.Logging.Test
         }
 
         [Test]
+        public void CategoryDecorationIsNull()
+        {
+            LogAssert.Expect(LogType.Log, $"[Info:test] dummy");
+            LogAssert.Expect(LogType.Log, $"[Info:test1] dummy");
+            LogAssert.Expect(LogType.Log, $"[Info:test2] dummy");
+
+            var writer = new UnityDebugLogWriter(null);
+            LoggingManager.Initialize(writer: writer);
+
+            var test = LoggingManager.GetLogger("test");
+            var test1 = LoggingManager.GetLogger("test1");
+            var test2 = LoggingManager.GetLogger("test2");
+
+            test.LogInfo("dummy");
+            test1.LogInfo("dummy");
+            test2.LogInfo("dummy");
+
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void CategoryDecorationIsEmpty()
+        {
+            LogAssert.Expect(LogType.Log, $"[Info:test] dummy");
+            LogAssert.Expect(LogType.Log, $"[Info:test1] dummy");
+            LogAssert.Expect(LogType.Log, $"[Info:test2] dummy");
+
+            var writer = new UnityDebugLogWriter(new Dictionary<string, UnityDebugLogFormat>());
+            LoggingManager.Initialize(writer: writer);
+
+            var test = LoggingManager.GetLogger("test");
+            var test1 = LoggingManager.GetLogger("test1");
+            var test2 = LoggingManager.GetLogger("test2");
+
+            test.LogInfo("dummy");
+            test1.LogInfo("dummy");
+            test2.LogInfo("dummy");
+
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void CategoryDecoration()
+        {
+            LogAssert.Expect(LogType.Log, $"<color=#0000FF>[Info:test] dummy</color>");
+            LogAssert.Expect(LogType.Log, $"[Info:test1] dummy");
+            LogAssert.Expect(LogType.Log, $"<color=#000000>[Info:test2] dummy</color>");
+
+            var format = new UnityDebugLogFormat("test", Color.blue);
+            var format2 = new UnityDebugLogFormat("test2");
+            var formats = new Dictionary<string, UnityDebugLogFormat>
+            {
+                { format.Category, format }, { format2.Category, format2 }
+            };
+            var writer = new UnityDebugLogWriter(formats);
+            LoggingManager.Initialize(writer: writer);
+
+            var test = LoggingManager.GetLogger("test");
+            var test1 = LoggingManager.GetLogger("test1");
+            var test2 = LoggingManager.GetLogger("test2");
+
+            test.LogInfo("dummy");
+            test1.LogInfo("dummy");
+            test2.LogInfo("dummy");
+
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
         public void ChangeLogWriter()
         {
             #region Settings

--- a/Tests/Runtime/LoggingManagerTest.cs
+++ b/Tests/Runtime/LoggingManagerTest.cs
@@ -377,7 +377,7 @@ namespace Extreal.Core.Logging.Test
             LogAssert.Expect(LogType.Log, $"[Info:test1] dummy");
             LogAssert.Expect(LogType.Log, $"[Info:test2] dummy");
 
-            var writer = new UnityDebugLogWriter(new Dictionary<string, UnityDebugLogFormat>());
+            var writer = new UnityDebugLogWriter(new List<UnityDebugLogFormat>());
             LoggingManager.Initialize(writer: writer);
 
             var test = LoggingManager.GetLogger("test");
@@ -400,11 +400,7 @@ namespace Extreal.Core.Logging.Test
 
             var format = new UnityDebugLogFormat("test", Color.blue);
             var format2 = new UnityDebugLogFormat("test2");
-            var formats = new Dictionary<string, UnityDebugLogFormat>
-            {
-                { format.Category, format }, { format2.Category, format2 }
-            };
-            var writer = new UnityDebugLogWriter(formats);
+            var writer = new UnityDebugLogWriter(new List<UnityDebugLogFormat> { format, format2 });
             LoggingManager.Initialize(writer: writer);
 
             var test = LoggingManager.GetLogger("test");

--- a/Tests/Runtime/LoggingManagerTest.cs
+++ b/Tests/Runtime/LoggingManagerTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -237,6 +238,68 @@ namespace Extreal.Core.Logging.Test
             LogAssert.Expect(LogType.Error, $"[{LogLevel.Error}:{logCategory}] {message}");
             logger.LogError(message, exception);
             LogAssert.Expect(LogType.Error, $"[{LogLevel.Error}:{logCategory}] {message}\n----------\n{exception}");
+        }
+
+        [Test]
+        public void CategoryFilterIsNull()
+        {
+            LogAssert.Expect(LogType.Log, $"[Info:test] dummy");
+            LogAssert.Expect(LogType.Log, $"[Info:test1] dummy");
+            LogAssert.Expect(LogType.Log, $"[Info:test2] dummy");
+
+            var checker = new LogLevelLogOutputChecker(null);
+            LoggingManager.Initialize(checker: checker);
+
+            var test = LoggingManager.GetLogger("test");
+            var test1 = LoggingManager.GetLogger("test1");
+            var test2 = LoggingManager.GetLogger("test2");
+
+            test.LogInfo("dummy");
+            test1.LogInfo("dummy");
+            test2.LogInfo("dummy");
+
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void CategoryFilterIsEmpty()
+        {
+            LogAssert.Expect(LogType.Log, $"[Info:test] dummy");
+            LogAssert.Expect(LogType.Log, $"[Info:test1] dummy");
+            LogAssert.Expect(LogType.Log, $"[Info:test2] dummy");
+
+            var checker = new LogLevelLogOutputChecker(new List<string>());
+            LoggingManager.Initialize(checker: checker);
+
+            var test = LoggingManager.GetLogger("test");
+            var test1 = LoggingManager.GetLogger("test1");
+            var test2 = LoggingManager.GetLogger("test2");
+
+            test.LogInfo("dummy");
+            test1.LogInfo("dummy");
+            test2.LogInfo("dummy");
+
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void CategoryFilter()
+        {
+            LogAssert.Expect(LogType.Log, $"[Info:test] dummy");
+            LogAssert.Expect(LogType.Log, $"[Info:test2] dummy");
+
+            var checker = new LogLevelLogOutputChecker(new List<string> {"test", "test2"});
+            LoggingManager.Initialize(checker: checker);
+
+            var test = LoggingManager.GetLogger("test");
+            var test1 = LoggingManager.GetLogger("test1");
+            var test2 = LoggingManager.GetLogger("test2");
+
+            test.LogInfo("dummy");
+            test1.LogInfo("dummy");
+            test2.LogInfo("dummy");
+
+            LogAssert.NoUnexpectedReceived();
         }
 
         [Test]


### PR DESCRIPTION
# 何の変更を加えましたか？

Commitsを見てください。

# 何を確認しましたか?

## 実装

- [x] Frameworkの誤った使い方にすぐに気づけるように、無効な引数や無効なメソッド呼び出しに対するチェックが入っていることを確認しました
- [x] Framework実行時の動きが分かるように、ログ（Error/Warn/Info/Debug）を出力していることを確認しました
- [x] 静的解析で問題が見つからないことを確認しました
- [x] フレームワーク利用者が使うAPI（主にprivate以外）に C# ドキュメントを記述しました

## テスト

- [x] 全ての自動テストが成功することを確認しました
- [x] テストカバレッジが100%になることを確認しました
- [x] サンプルがあるものはサンプルが動作することを確認しました

## 変更影響

- [x] GuideのReleaseページに変更内容が追加されることを確認しました
- [x] GuideのModuleページ（機能ページ）に変更が反映されることを確認しました
  - https://github.com/extreal-dev/Extreal.Guide/pull/41
- [x] GuideのLearningページに変更が反映されることを確認しました
  - 影響なし
- [x] Sample Applicationに変更が反映されることを確認しました
  - 別PBIで対応

# レビュアーへのメッセージ
