### PR TITLE
Change the range of log coloring for each log category to messages

### DIFF
--- a/Runtime/UnityDebugLogWriter.cs
+++ b/Runtime/UnityDebugLogWriter.cs
@@ -73,13 +73,13 @@ namespace Extreal.Core.Logging
                 .Append(logCategory)
                 .Append("] ")
                 .Append(message);
-            if (exception != null)
-            {
-                _ = stringBuilder.Append("\n----------\n").Append(exception);
-            }
             if (colorRGB != null)
             {
                 stringBuilder.Append("</color>");
+            }
+            if (exception != null)
+            {
+                _ = stringBuilder.Append("\n----------\n").Append(exception);
             }
             return stringBuilder.ToString();
         }

--- a/Tests/Runtime/LoggingManagerTest.cs
+++ b/Tests/Runtime/LoggingManagerTest.cs
@@ -397,6 +397,7 @@ namespace Extreal.Core.Logging.Test
             LogAssert.Expect(LogType.Log, $"<color=#0000FF>[Info:test] dummy</color>");
             LogAssert.Expect(LogType.Log, $"[Info:test1] dummy");
             LogAssert.Expect(LogType.Log, $"<color=#000000>[Info:test2] dummy</color>");
+            LogAssert.Expect(LogType.Log, $"<color=#000000>[Info:test2] dummy</color>\n----------\n{exception}");
 
             var format = new UnityDebugLogFormat("test", Color.blue);
             var format2 = new UnityDebugLogFormat("test2");
@@ -410,6 +411,7 @@ namespace Extreal.Core.Logging.Test
             test.LogInfo("dummy");
             test1.LogInfo("dummy");
             test2.LogInfo("dummy");
+            test2.LogInfo("dummy", exception);
 
             LogAssert.NoUnexpectedReceived();
         }


### PR DESCRIPTION
# 何の変更を加えましたか？

- ログカテゴリ毎のログの色付けの範囲をメッセージまでに変更しました。
- これまでは例外も含めてましたがUnity EditorのConsole上で色が付かないので今回の対応を入れました。

# 何を確認しましたか?

## 実装

- [x] Frameworkの誤った使い方にすぐに気づけるように、無効な引数や無効なメソッド呼び出しに対するチェックが入っていることを確認しました
- [x] Framework実行時の動きが分かるように、ログ（Error/Warn/Info/Debug）を出力していることを確認しました
- [x] 静的解析で問題が見つからないことを確認しました
- [x] フレームワーク利用者が使うAPI（主にprivate以外）に C# ドキュメントを記述しました

## テスト

- [x] 全ての自動テストが成功することを確認しました
- [x] テストカバレッジが100%になることを確認しました
- [x] サンプルがあるものはサンプルが動作することを確認しました
  - サンプルなし

## 変更影響

- [x] GuideのReleaseページに変更内容が追加されることを確認しました
- [x] GuideのModuleページ（機能ページ）に変更が反映されることを確認しました
- [x] GuideのLearningページに変更が反映されることを確認しました
- [x] Sample Applicationに変更が反映されることを確認しました

↑すべて影響なし

# レビュアーへのメッセージ
